### PR TITLE
updating to API version 2022.6

### DIFF
--- a/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Banking/SpendMoneyAttachmentData.cs
+++ b/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Banking/SpendMoneyAttachmentData.cs
@@ -1,4 +1,4 @@
-﻿namespace MYOB.AccountRight.SDK.Contracts.Version2.Banking
+namespace MYOB.AccountRight.SDK.Contracts.Version2.Banking
 {
     /// <summary>
     /// Describes the AttachmentData object

--- a/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Banking/SpendMoneyAttachmentWrapper.cs
+++ b/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Banking/SpendMoneyAttachmentWrapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace MYOB.AccountRight.SDK.Contracts.Version2.Banking

--- a/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Purchase/BillAttachmentData.cs
+++ b/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Purchase/BillAttachmentData.cs
@@ -1,4 +1,4 @@
-﻿namespace MYOB.AccountRight.SDK.Contracts.Version2.Purchase
+namespace MYOB.AccountRight.SDK.Contracts.Version2.Purchase
 {
     /// <summary>
     /// Describes the BillAttachmentData object

--- a/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Purchase/BillAttachmentWrapper.cs
+++ b/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Purchase/BillAttachmentWrapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace MYOB.AccountRight.SDK.Contracts.Version2.Purchase

--- a/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Purchase/BillAttachmentsData.cs
+++ b/MYOB.API.SDK/SDK.NET45/Contracts/Version2/Purchase/BillAttachmentsData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace MYOB.AccountRight.SDK.Contracts.Version2.Purchase

--- a/MYOB.API.SDK/SDK.NET45/Services/Version2/Banking/SpendMoneyAttachmentService.cs
+++ b/MYOB.API.SDK/SDK.NET45/Services/Version2/Banking/SpendMoneyAttachmentService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using MYOB.AccountRight.SDK.Communication;
 using MYOB.AccountRight.SDK.Contracts;
 using System.Collections.Generic;

--- a/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/BillAttachmentsDataService.cs
+++ b/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/BillAttachmentsDataService.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Communication;
+using MYOB.AccountRight.SDK.Communication;
 using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Contracts.Version2.Purchase;
 using System;

--- a/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/ItemBillAttachmentService.cs
+++ b/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/ItemBillAttachmentService.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Communication;
+using MYOB.AccountRight.SDK.Communication;
 using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Contracts.Version2;
 using MYOB.AccountRight.SDK.Contracts.Version2.Purchase;

--- a/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/MiscellaneousBillAttachmentService.cs
+++ b/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/MiscellaneousBillAttachmentService.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Communication;
+using MYOB.AccountRight.SDK.Communication;
 using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Contracts.Version2;
 using MYOB.AccountRight.SDK.Contracts.Version2.Purchase;

--- a/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/ProfessionalBillAttachmentService.cs
+++ b/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/ProfessionalBillAttachmentService.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Communication;
+using MYOB.AccountRight.SDK.Communication;
 using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Contracts.Version2;
 using MYOB.AccountRight.SDK.Contracts.Version2.Purchase;

--- a/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/ServiceBillAttachmentService.cs
+++ b/MYOB.API.SDK/SDK.NET45/Services/Version2/Purchase/ServiceBillAttachmentService.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Communication;
+using MYOB.AccountRight.SDK.Communication;
 using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Contracts.Version2;
 using MYOB.AccountRight.SDK.Contracts.Version2.Purchase;

--- a/MYOB.API.SDK/SDK.Test/Contracts/CompanyFileSubscriptionTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Contracts/CompanyFileSubscriptionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/MYOB.API.SDK/SDK.Test/Contracts/Version2/BillAttachmentWrapperTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Contracts/Version2/BillAttachmentWrapperTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Contracts.Version2.Purchase;
+using MYOB.AccountRight.SDK.Contracts.Version2.Purchase;
 using NUnit.Framework;
 
 namespace SDK.Test.Contracts.Version2

--- a/MYOB.API.SDK/SDK.Test/Contracts/Version2/SpendMoneyAttachmentWrapperTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Contracts/Version2/SpendMoneyAttachmentWrapperTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Contracts.Version2.Banking;
+using MYOB.AccountRight.SDK.Contracts.Version2.Banking;
 using NUnit.Framework;
 
 namespace SDK.Test.Contracts.Version2

--- a/MYOB.API.SDK/SDK.Test/Services/BalanceSheetSummaryServiceTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Services/BalanceSheetSummaryServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Services;
+using MYOB.AccountRight.SDK.Services;
 using NUnit.Framework;
 
 namespace SDK.Test.Services

--- a/MYOB.API.SDK/SDK.Test/Services/CustomListServiceTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Services/CustomListServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Services.Company;
+using MYOB.AccountRight.SDK.Services.Company;
 using NUnit.Framework;
 
 namespace SDK.Test.Services

--- a/MYOB.API.SDK/SDK.Test/Services/ItemBillAttachmentServiceTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Services/ItemBillAttachmentServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Contracts;
+using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Services.Purchase;
 using NUnit.Framework;
 using System;

--- a/MYOB.API.SDK/SDK.Test/Services/MiscellaneousBillAttachmentServiceTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Services/MiscellaneousBillAttachmentServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Contracts;
+using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Services.Purchase;
 using NUnit.Framework;
 using System;

--- a/MYOB.API.SDK/SDK.Test/Services/ProfessionalBillAttachmentServiceTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Services/ProfessionalBillAttachmentServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Contracts;
+using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Services.Purchase;
 using NUnit.Framework;
 using System;

--- a/MYOB.API.SDK/SDK.Test/Services/ServiceBillAttachmentServiceTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Services/ServiceBillAttachmentServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Contracts;
+using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Services.Purchase;
 using NUnit.Framework;
 using System;

--- a/MYOB.API.SDK/SDK.Test/Services/SpendMoneyAttachmentServiceTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Services/SpendMoneyAttachmentServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Contracts;
+using MYOB.AccountRight.SDK.Contracts;
 using MYOB.AccountRight.SDK.Services.Banking;
 using NUnit.Framework;
 using System;

--- a/MYOB.API.SDK/SDK/Contracts/Subscription.cs
+++ b/MYOB.API.SDK/SDK/Contracts/Subscription.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace MYOB.AccountRight.SDK.Contracts
 {

--- a/MYOB.API.SDK/SDK/Contracts/Version2/Company/CustomList.cs
+++ b/MYOB.API.SDK/SDK/Contracts/Version2/Company/CustomList.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace MYOB.AccountRight.SDK.Contracts.Version2.Company
 {

--- a/MYOB.API.SDK/SDK/Contracts/Version2/Company/CustomListValue.cs
+++ b/MYOB.API.SDK/SDK/Contracts/Version2/Company/CustomListValue.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace MYOB.AccountRight.SDK.Contracts.Version2.Company
 {

--- a/MYOB.API.SDK/SDK/Contracts/Version2/Report/BalanceSheetSummary/BalanceSheetSummary.cs
+++ b/MYOB.API.SDK/SDK/Contracts/Version2/Report/BalanceSheetSummary/BalanceSheetSummary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using MYOB.AccountRight.SDK.Contracts.Version2.GeneralLedger;
 using MYOB.AccountRight.SDK.Contracts.Version2.Report.TaxCodeSummary;

--- a/MYOB.API.SDK/SDK/Contracts/Version2/Sale/SaleQuoteStatus.cs
+++ b/MYOB.API.SDK/SDK/Contracts/Version2/Sale/SaleQuoteStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace MYOB.AccountRight.SDK.Contracts.Version2.Sale
+namespace MYOB.AccountRight.SDK.Contracts.Version2.Sale
 {
     /// <summary>
     /// Quote Status Type

--- a/MYOB.API.SDK/SDK/Services/Version2/Company/CustomListService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Company/CustomListService.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Communication;
+using MYOB.AccountRight.SDK.Communication;
 using MYOB.AccountRight.SDK.Contracts.Version2.Company;
 
 namespace MYOB.AccountRight.SDK.Services.Company

--- a/MYOB.API.SDK/SDK/Services/Version2/Report/BalanceSheetSummary/BalanceSheetSummaryService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Report/BalanceSheetSummary/BalanceSheetSummaryService.cs
@@ -1,4 +1,4 @@
-﻿using MYOB.AccountRight.SDK.Communication;
+using MYOB.AccountRight.SDK.Communication;
 using MYOB.AccountRight.SDK.Contracts.Version2.Report.BalanceSheetSummary;
 
 namespace MYOB.AccountRight.SDK.Services

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2022.4.{build}
+version: 2022.6.{build}
 shallow_clone: true
 assembly_info:
   patch: true


### PR DESCRIPTION
This should have been a single file change of appveyor.yaml, however due to BOM/UTF issue we have a large change set. This will remove the BOM characters as it's a copy from Huxley that didn't have BOM characters. Hoping they won't get introduced again. 