### PR TITLE
Moving appveyor to the global config YAML

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,3 @@
-version: 2024.2.{build}
 shallow_clone: true
 assembly_info:
   patch: true
@@ -23,20 +22,6 @@ artifacts:
 - path: .\Artefacts\Coverage\output.xml
   name: Coverage
 deploy:
-- provider: NuGet
-  api_key:
-    secure: 3ywSGEsVhWpYoxnDrzYQ6+ItAb89J4M5xd76ApZ/w8c00AmunXex918M5Yn89YkZ
-  skip_symbols: true
-  artifact: Release
-  on:
-    branch: release
-- provider: NuGet
-  api_key:
-    secure: 3ywSGEsVhWpYoxnDrzYQ6+ItAb89J4M5xd76ApZ/w8c00AmunXex918M5Yn89YkZ
-  skip_symbols: true
-  artifact: Candidate
-  on:
-    branch: candidate
 - provider: NuGet
   server: https://www.myget.org/F/myob-developers/api/v2
   api_key:


### PR DESCRIPTION
Both version and NuGet API key is now located in inside https://ci.appveyor.com/tools/global-yaml 