### PR TITLE
Add back version and assembly_info

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,11 @@
+version: 2024.2.{build}
+shallow_clone: true
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
 environment:
   COVERALLS_REPO_TOKEN:
     secure: XBCyPFZbO55cEI6tMsd1Ts3O7sXF3IFCxGPYQGJbVae48G9j9miONIHmDwzG4iLG


### PR DESCRIPTION
- Add back `shallow_clone ` and `assembly_info`. they were mistakenly removed during resolve conflict.
- The API error is gone, but somehow the version isn't captured from the global config. reverting that part of the info back to local file.
![111](https://github.com/myob-oss/AccountRight_Live_API_.Net_SDK/assets/120345965/709be358-4c34-4a80-95b3-6f8cd276a7e4)
