### PR TITLE
Allow custom implementation of API Request Handler

### DIFF
--- a/MYOB.API.SDK/SDK/Communication/ApiRequestHandler.cs
+++ b/MYOB.API.SDK/SDK/Communication/ApiRequestHandler.cs
@@ -13,7 +13,7 @@ namespace MYOB.AccountRight.SDK.Communication
     /// <summary>
     /// Handles API requests
     /// </summary>
-    public class ApiRequestHandler : BaseRequestHandler
+    public class ApiRequestHandler : BaseRequestHandler, IApiRequestHandler
     {
         /// <summary>
         /// The default production endpoint

--- a/MYOB.API.SDK/SDK/IApiRequestHandler.cs
+++ b/MYOB.API.SDK/SDK/IApiRequestHandler.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MYOB.AccountRight.SDK
+{
+    /// <summary>
+    /// Interface for custom API request handling
+    /// </summary>
+    public interface IApiRequestHandler
+    {
+        /// <summary>
+        /// GET - asynchronous - using actions as handlers
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="onComplete"></param>
+        /// <param name="onError"></param>
+        /// <param name="eTag"></param>
+        void Get<T>(WebRequest request, Action<HttpStatusCode, T> onComplete, Action<Uri, Exception> onError, string eTag) where T : class;
+
+        /// <summary>
+        /// DELETE - asynchronous - using actions as handlers
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="onComplete"></param>
+        /// <param name="onError"></param>
+        void Delete(WebRequest request, Action<HttpStatusCode> onComplete, Action<Uri, Exception> onError);
+
+        /// <summary>
+        /// PUT - asynchronous - using actions as handlers
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <param name="onComplete"></param>
+        /// <param name="onError"></param>
+        void Put<T>(WebRequest request, T entity, Action<HttpStatusCode, string> onComplete, Action<Uri, Exception> onError);
+
+        /// <summary>
+        /// PUT - asynchronous - using actions as handlers
+        /// </summary>
+        /// <typeparam name="TRequest"></typeparam>
+        /// <typeparam name="TResponse"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <param name="onComplete"></param>
+        /// <param name="onError"></param>
+        void Put<TRequest, TResponse>(WebRequest request, TRequest entity, Action<HttpStatusCode, string, TResponse> onComplete, Action<Uri, Exception> onError) where TResponse : class;
+
+        /// <summary>
+        /// POST - asynchronous - using actions as handlers
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <param name="onComplete"></param>
+        /// <param name="onError"></param>
+        void Post<T>(WebRequest request, T entity, Action<HttpStatusCode, string> onComplete, Action<Uri, Exception> onError) where T : class;
+
+        /// <summary>
+        /// POST - asynchronous - using actions as handlers
+        /// </summary>
+        /// <typeparam name="TRequest"></typeparam>
+        /// <typeparam name="TResponse"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <param name="onComplete"></param>
+        /// <param name="onError"></param>
+        void Post<TRequest, TResponse>(WebRequest request, TRequest entity, Action<HttpStatusCode, string, TResponse> onComplete, Action<Uri, Exception> onError) where TResponse : class;
+
+#if ASYNC
+        /// <summary>
+        /// GET - async - awaitable
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="eTag"></param>
+        /// <returns></returns>
+        Task<Tuple<HttpStatusCode, T>> GetAsync<T>(WebRequest request, string eTag) where T : class;
+
+        /// <summary>
+        /// GET - async - awaitable
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
+        /// <param name="eTag"></param>
+        /// <returns></returns>
+        Task<Tuple<HttpStatusCode, T>> GetAsync<T>(WebRequest request, CancellationToken cancellationToken, string eTag) where T : class;
+
+        /// <summary>
+        /// DELETE - async - awaitable
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        Task DeleteAsync(WebRequest request);
+
+        /// <summary>
+        /// DELETE - async - awaitable
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task DeleteAsync(WebRequest request, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// PUT - async - awaitable 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Task<string> PutAsync<T>(WebRequest request, T entity) where T : class;
+
+        /// <summary>
+        /// PUT - async - awaitable
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<string> PutAsync<T>(WebRequest request, T entity, CancellationToken cancellationToken) where T : class;
+
+        /// <summary>
+        /// PUT - async - awaitable
+        /// </summary>
+        /// <typeparam name="TRequestEntity"></typeparam>
+        /// <typeparam name="TResponseEntity"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Task<TResponseEntity> PutAsync<TRequestEntity, TResponseEntity>(WebRequest request, TRequestEntity entity) where TRequestEntity : class where TResponseEntity : class;
+
+        /// <summary>
+        /// PUT - async - awaitable
+        /// </summary>
+        /// <typeparam name="TRequestEntity"></typeparam>
+        /// <typeparam name="TResponseEntity"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<TResponseEntity> PutAsync<TRequestEntity, TResponseEntity>(WebRequest request, TRequestEntity entity, CancellationToken cancellationToken) where TRequestEntity : class where TResponseEntity : class;
+
+        /// <summary>
+        /// POST - async - awaitable
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Task<string> PostAsync<T>(WebRequest request, T entity) where T : class;
+
+        /// <summary>
+        /// POST - async - awaitable
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<string> PostAsync<T>(WebRequest request, T entity, CancellationToken cancellationToken) where T : class;
+
+        /// <summary>
+        /// POST - async - awaitable
+        /// </summary>
+        /// <typeparam name="TRequestEntity"></typeparam>
+        /// <typeparam name="TResponseEntity"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Task<TResponseEntity> PostAsync<TRequestEntity, TResponseEntity>(WebRequest request, TRequestEntity entity) where TRequestEntity : class where TResponseEntity : class;
+
+        /// <summary>
+        /// POST - async - awaitable
+        /// </summary>
+        /// <typeparam name="TRequestEntity"></typeparam>
+        /// <typeparam name="TResponseEntity"></typeparam>
+        /// <param name="request"></param>
+        /// <param name="entity"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<TResponseEntity> PostAsync<TRequestEntity, TResponseEntity>(WebRequest request, TRequestEntity entity, CancellationToken cancellationToken) where TRequestEntity : class where TResponseEntity : class;
+
+#endif
+    }
+}

--- a/MYOB.API.SDK/SDK/SDK.csproj
+++ b/MYOB.API.SDK/SDK/SDK.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Extensions\SslProtocolsExtensions.cs" />
     <Compile Include="Extensions\WebRequestExtensions.cs" />
     <Compile Include="IApiConfiguration.cs" />
+    <Compile Include="IApiRequestHandler.cs" />
     <Compile Include="IWebRequestFactory.cs" />
     <Compile Include="ApiConfiguration.cs" />
     <Compile Include="Communication\BaseRequestHandler.cs" />

--- a/MYOB.API.SDK/SDK/Services/CompanyFileService.cs
+++ b/MYOB.API.SDK/SDK/Services/CompanyFileService.cs
@@ -21,8 +21,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public CompanyFileService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null) 
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public CompanyFileService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null) 
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/CompanyService.cs
+++ b/MYOB.API.SDK/SDK/Services/CompanyService.cs
@@ -13,8 +13,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public CompanyService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public CompanyService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Company/CompanyPreferencesService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Company/CompanyPreferencesService.cs
@@ -14,8 +14,9 @@ namespace MYOB.AccountRight.SDK.Services.Company
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public CompanyPreferencesService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public CompanyPreferencesService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/CurrentUserService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/CurrentUserService.cs
@@ -7,15 +7,16 @@ namespace MYOB.AccountRight.SDK.Services
     /// A service that provides access to the <see cref="CurrentUser"/> resources
     /// </summary>
     public class CurrentUserService : GetOnlyService<CurrentUser> // : ServiceBase
-    {       
+    {
         /// <summary>
         /// Initialise a service that can use <see cref="CurrentUser"/> resources
         /// </summary>
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public CurrentUserService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public CurrentUserService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/GeneralLedger/AccountBudgetService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/GeneralLedger/AccountBudgetService.cs
@@ -24,9 +24,10 @@ namespace MYOB.AccountRight.SDK.Services.GeneralLedger
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
         public AccountBudgetService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null,
-                                IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+                                IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/GeneralLedger/ProfitLossDistributionService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/GeneralLedger/ProfitLossDistributionService.cs
@@ -14,8 +14,9 @@ namespace MYOB.AccountRight.SDK.Services.GeneralLedger
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public ProfitLossDistributionService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public ProfitLossDistributionService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/GetOnlyService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/GetOnlyService.cs
@@ -25,8 +25,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        protected GetOnlyService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        protected GetOnlyService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Payroll/TimesheetService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Payroll/TimesheetService.cs
@@ -163,8 +163,9 @@ namespace MYOB.AccountRight.SDK.Services.Payroll
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public TimesheetService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public TimesheetService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Purchase/CalculateDiscountsService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Purchase/CalculateDiscountsService.cs
@@ -22,8 +22,9 @@ namespace MYOB.AccountRight.SDK.Services.Purchase
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public CalculateDiscountsService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public CalculateDiscountsService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Purchase/SupplierPaymentRecordWithDiscountsAndFeesService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Purchase/SupplierPaymentRecordWithDiscountsAndFeesService.cs
@@ -22,8 +22,9 @@ namespace MYOB.AccountRight.SDK.Services.Purchase
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public SupplierPaymentRecordWithDiscountsAndFeesService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public SupplierPaymentRecordWithDiscountsAndFeesService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/ReadableRangeService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/ReadableRangeService.cs
@@ -24,8 +24,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        protected ReadableRangeService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory, IOAuthKeyService keyService)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        protected ReadableRangeService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory, IOAuthKeyService keyService, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Report/BalanceSheetSummary/BalanceSheetSummaryService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Report/BalanceSheetSummary/BalanceSheetSummaryService.cs
@@ -14,8 +14,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public BalanceSheetSummaryService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public BalanceSheetSummaryService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Report/GST/NzgstReportService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Report/GST/NzgstReportService.cs
@@ -14,8 +14,9 @@ namespace MYOB.AccountRight.SDK.Services.Report.GST
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public NZGSTReportService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public NZGSTReportService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Report/PayrollCategorySummary/PayrollCategorySummaryService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Report/PayrollCategorySummary/PayrollCategorySummaryService.cs
@@ -14,8 +14,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public PayrollCategorySummaryService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public PayrollCategorySummaryService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Report/ProfitAndLossSummary/ProfitAndLossSummaryService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Report/ProfitAndLossSummary/ProfitAndLossSummaryService.cs
@@ -15,8 +15,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public ProfitAndLossSummaryService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public ProfitAndLossSummaryService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Report/TaxCodeSummary/TaxCodeSummaryService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Report/TaxCodeSummary/TaxCodeSummaryService.cs
@@ -14,8 +14,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public TaxCodeSummaryService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public TaxCodeSummaryService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Sale/CalculateDiscountsFeesService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Sale/CalculateDiscountsFeesService.cs
@@ -22,8 +22,9 @@ namespace MYOB.AccountRight.SDK.Services.Sale
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public CalculateDiscountsFeesService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public CalculateDiscountsFeesService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Sale/CustomerPaymentRecordWithDiscountsAndFeesService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Sale/CustomerPaymentRecordWithDiscountsAndFeesService.cs
@@ -22,8 +22,9 @@ namespace MYOB.AccountRight.SDK.Services.Sale
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public CustomerPaymentRecordWithDiscountsAndFeesService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public CustomerPaymentRecordWithDiscountsAndFeesService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/Version2/Sale/SaleEmailService.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/Sale/SaleEmailService.cs
@@ -22,8 +22,9 @@ namespace MYOB.AccountRight.SDK.Services.Sale
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public SaleEmailService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null)
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public SaleEmailService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory = null, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null)
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 

--- a/MYOB.API.SDK/SDK/Services/VersionInfoService.cs
+++ b/MYOB.API.SDK/SDK/Services/VersionInfoService.cs
@@ -20,8 +20,9 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="configuration">The configuration required to communicate with the API service</param>
         /// <param name="webRequestFactory">A custom implementation of the <see cref="WebRequestFactory"/>, if one is not supplied a default <see cref="WebRequestFactory"/> will be used.</param>
         /// <param name="keyService">An implementation of a service that will store/persist the OAuth tokens required to communicate with the cloud based API at http://api.myob.com/accountright </param>
-        public VersionInfoService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory, IOAuthKeyService keyService = null) 
-            : base(configuration, webRequestFactory, keyService)
+        /// <param name="apiRequestHandler">A custom implementation of the <see cref="IApiRequestHandler"/>, if one is not supplied a default <see cref="ApiRequestHandler"/> will be used.</param>
+        public VersionInfoService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory, IOAuthKeyService keyService = null, IApiRequestHandler apiRequestHandler = null) 
+            : base(configuration, webRequestFactory, keyService, apiRequestHandler)
         {
         }
 


### PR DESCRIPTION
Added in IApiRequestHandler so that custom logic can be applied to the underlying API request handling by integrators. Will fallback to using the current implementation of `ApiRequestHandler` if an instance is not passed into the service (so this is not a breaking change for existing implementations)

Example usages of this interface:

- Adding custom logging to outgoing HTTP requests
- Implementing retry logic within the HTTP handler for responses such as 429 too many requests or 504 gateway timeout