### PR TITLE
Update DebitSettlementLineType.cs

### DIFF
--- a/MYOB.API.SDK/SDK/Contracts/Version2/Purchase/DebitSettlementLineType.cs
+++ b/MYOB.API.SDK/SDK/Contracts/Version2/Purchase/DebitSettlementLineType.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// Purged bill type
         /// </summary>
-        Purged
+        Purged,
+
+        /// <summary>
+        /// Likely a legacy data issue
+        /// </summary>
+        NotSet        
     }
 }


### PR DESCRIPTION
Error converting value "NotSet" to type 'MYOB.AccountRight.SDK.Contracts.Version2.Purchase.DebitSettlementLineType'.

A little more context -> Encountered an operation error (https://arl2.api.myob.com/accountright/2ebde597-27f9-4a97-a286-fcce9b9e4749/Purchase/DebitSettlement/?$top=300&$skip=0&$orderby=Date&$filter=Date ge datetime'2023-05-13T04:09:30'

Looks like the error has been around for a long time but only occurs on certain files, likely an issue with legacy data. 

Really hoping not to create our own fork to resolve this as it's quite urgent!